### PR TITLE
docs: fix simple typo, exhange -> exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Pear is a WebRTC SDK written in C. The SDK aims to integrate IoT/Embedded device
 
 ### Examples
 - [Local file](https://github.com/sepfy/pear/tree/main/examples/local_file): Stream h264 file to browser and exchange SDP by copy and paste.
-- [GStreamer](https://github.com/sepfy/pear/tree/main/examples/gstreamer): Stream v4l2 source to browser with GStreamer and exhange SDP by libevent HTTP server.
+- [GStreamer](https://github.com/sepfy/pear/tree/main/examples/gstreamer): Stream v4l2 source to browser with GStreamer and exchange SDP by libevent HTTP server.


### PR DESCRIPTION
There is a small typo in README.md.

Should read `exchange` rather than `exhange`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md