### PR TITLE
fix crash due to misinitialization of PeerConnection

### DIFF
--- a/src/peer_connection.c
+++ b/src/peer_connection.c
@@ -256,7 +256,7 @@ PeerConnection* peer_connection_create(void) {
 
   PeerConnection *pc = NULL;
   pc = (PeerConnection*)malloc(sizeof(PeerConnection));
-
+  memset(pc, 0, sizeof(*pc));
   if(pc == NULL)
     return pc;
 


### PR DESCRIPTION
If `PeerConnection` is not zeroed upon creation checking for its field to NULL is meaningless (as fields contain garbage) and leads to sigsegvs.
For example this happens in `peer_connection_ice_recv_cb`:
```c
    if(pc->ontrack != NULL) {
      pc->ontrack(buf, len, pc->ontrack_userdata);
    }
```
This PR contains hotfix for this problem.