### PR TITLE
Check the result of SSL certificate verification

### DIFF
--- a/src/dtls_transport.c
+++ b/src/dtls_transport.c
@@ -325,6 +325,11 @@ void dtls_transport_incomming_msg(DtlsTransport *dtls_transport, char *buf, int 
   if(!rcert) {
     LOG_ERROR("%s", ERR_reason_error_string(ERR_get_error()));
   }
+  else if(SSL_get_verify_result(dtls_transport->ssl) != X509_V_OK) {
+    LOG_ERROR("Certificate verification failed");
+    X509_free(rcert);
+    rcert = NULL;
+  }
   else {
     unsigned int rsize;
     unsigned char rfingerprint[EVP_MAX_MD_SIZE];


### PR DESCRIPTION
It is unsafe to use a certificate without checking if it is valid.