### PR TITLE
Add return statements for non-void functions

### DIFF
--- a/src/dtls_transport.c
+++ b/src/dtls_transport.c
@@ -248,7 +248,7 @@ int dtls_transport_sctp_to_dtls(DtlsTransport *dtls_transport, uint8_t *data, in
   if(SSL_write(dtls_transport->ssl, data, bytes) != bytes) {
     //LOG_WARN("");
   }
-
+  return bytes;
 }
 
 int dtls_transport_decrypt_data(DtlsTransport *dtls_transport, char *encrypted_data, int encrypted_len,

--- a/src/peer_connection.c
+++ b/src/peer_connection.c
@@ -89,7 +89,7 @@ static void* peer_connection_component_state_chanaged_cb(NiceAgent *agent,
   if(pc->oniceconnectionstatechange != NULL) {
     pc->oniceconnectionstatechange(state, pc->userdata);
   }
-
+  return NULL;
 }
 
 static void peer_connection_candidates_to_sdp(PeerConnection *pc, SessionDescription *sdp) {
@@ -255,6 +255,7 @@ static void* peer_connection_candidate_gathering_done_cb(NiceAgent *agent, guint
     pc->onicecandidate(sdp_content, pc->userdata);
   }
 
+  return NULL;
 }
 
 int peer_connection_send_rtcp_pil(PeerConnection *pc, uint32_t ssrc) {


### PR DESCRIPTION
All functions that are not void should return a value on every exit path.